### PR TITLE
ParrentCategory as admin

### DIFF
--- a/kanbanboard/app/Http/Controllers/ParentCategoryController.php
+++ b/kanbanboard/app/Http/Controllers/ParentCategoryController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 
 
 use App\Category;
-use App\ParentCategory
+use App\ParentCategory;
 use Auth;
 
 use DB;


### PR DESCRIPTION
Changed middleware on parent category controller since we’re not using auth:admin anymore.

I also added a missing semicolon;

Does the parent categorycontroller need use Auth for anything?