### PR TITLE
Updated limit check behavior

### DIFF
--- a/kanbanboard/public/js/kanbanBoard/boardFunctionality.js
+++ b/kanbanboard/public/js/kanbanBoard/boardFunctionality.js
@@ -194,7 +194,12 @@ function checkLimits()
         limitElement.css('color', 'black');
       }
 
-      limitElement.text("LIMIT: " + counter[key] + "/" + value);
+      if(value != 0) {
+        limitElement.html("LIMIT: " + counter[key] + "/" + value);
+      }
+      else {
+        limitElement.html("LIMIT: " + counter[key] + "/" + "&infin;");
+      }
     });
 
     $.each(parentCategories, function (index, value) {
@@ -215,6 +220,11 @@ function checkLimits()
         limitElement.css('color', 'black');
       }
 
-      limitElement.text("LIMIT: " + sum + "/" + limit);
+      if(limit != 0) {
+        limitElement.html("LIMIT: " + sum + "/" + limit);
+      }
+      else {
+        limitElement.html("LIMIT: " + sum + "/" + "&infin;");
+      }
     });
   }


### PR DESCRIPTION
This pull request relates to this comment from the client:

> 1. Work-in-process / limit shows only max not current number in each column which would be useful. For example:
a) WIP: 1/5 (in black)
b) WIP: 5/5 (in black)
c) WIP: 6/5 (in red, only red when crossed by border)

Also made categories and parent categories with a limit of 0 keep the same structure as above but with the limit shown as an &infin; symbol.
In other words, they render as 0/&infin; and 1/&infin; instead of 0/0 and 1/0.