### PR TITLE
Migration Cleanup

### DIFF
--- a/kanbanboard/database/migrations/2017_12_09_174037_forien_keys.php
+++ b/kanbanboard/database/migrations/2017_12_09_174037_forien_keys.php
@@ -27,10 +27,6 @@ class ForienKeys extends Migration
      */
     public function down()
     {
-      Schema::table('categories', function ($table) {
-          $table->dropForeign(['parentcategory']);
-      });
-
       Schema::table('cards', function ($table) {
           // Providing an array with all value didn't work, so I'm splitting it up.
           // This syntax means we don't have to provide the table name and the columns.


### PR DESCRIPTION
When I removed the parent category foreign key in the cascade fix I forgot to remove the dropForeign() for it. It doesn't lead to any errors but as it's unused code I'm removing it.